### PR TITLE
add compounded timeloss

### DIFF
--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Model\Attempt.cs" />
     <Compile Include="Model\AutoSplitter.cs" />
     <Compile Include="Model\AutoSplitterFactory.cs" />
+    <Compile Include="Model\Comparisons\CompoundedTimelossComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\LatestRunComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\WorstSegmentsComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\MedianSegmentsComparisonGenerator.cs" />

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/CompoundedTimelossComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/CompoundedTimelossComparisonGenerator.cs
@@ -1,0 +1,55 @@
+﻿using LiveSplit.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static System.Math;
+
+namespace LiveSplit.Model.Comparisons
+{
+    public class CompoundedTimelossComparisonGenerator : IComparisonGenerator
+    {
+        public IRun Run { get; set; }
+        public const string ComparisonName = "Compounded Timeloss";
+        public const string ShortComparisonName = "Compounded";
+        public string Name => ComparisonName;
+
+        public CompoundedTimelossComparisonGenerator(IRun run)
+        {
+            Run = run;
+        }
+
+        public void Generate(TimingMethod method)
+        {
+            var sob = TimeSpan.Zero;
+            var pb  = TimeSpan.Zero;
+            foreach (var segment in Run)
+            {
+                if (segment.BestSegmentTime[method] != null)
+                    sob += (TimeSpan)segment.BestSegmentTime[method];
+
+            }
+            
+            if (Run.LastOrDefault().PersonalBestSplitTime[method] != null)
+                pb = (TimeSpan)Run.LastOrDefault().PersonalBestSplitTime[method];
+            
+            var timeloss = pb - sob;
+
+            for (var ind = 0; ind < Run.Count; ind++)
+            {
+                TimeSpan? split = null;
+                if (Run[ind].BestSegmentTime[method] != null)
+                {
+                    timeloss += (TimeSpan)Run[ind].BestSegmentTime[method];
+                    split = timeloss;
+                }
+                Run[ind].Comparisons[Name] = new Time (method, split);
+            }
+        }
+
+        public void Generate(ISettings settings)
+        {
+            Generate(TimingMethod.RealTime);
+            Generate(TimingMethod.GameTime);
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
@@ -14,11 +14,13 @@ namespace LiveSplit.Model.Comparisons
             AddShortComparisonName(WorstSegmentsComparisonGenerator.ComparisonName, WorstSegmentsComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(PercentileComparisonGenerator.ComparisonName, PercentileComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(LatestRunComparisonGenerator.ComparisonName, LatestRunComparisonGenerator.ShortComparisonName);
+            AddShortComparisonName(CompoundedTimelossComparisonGenerator.ComparisonName, CompoundedTimelossComparisonGenerator.ShortComparisonName);
         }
         public IEnumerable<IComparisonGenerator> Create(IRun run)
         {
             yield return new BestSegmentsComparisonGenerator(run);
             yield return new AverageSegmentsComparisonGenerator(run);
+            yield return new CompoundedTimelossComparisonGenerator(run);
         }
 
         public IEnumerable<IComparisonGenerator> GetAllGenerators(IRun run)
@@ -30,6 +32,7 @@ namespace LiveSplit.Model.Comparisons
             yield return new WorstSegmentsComparisonGenerator(run);
             yield return new PercentileComparisonGenerator(run);
             yield return new LatestRunComparisonGenerator(run);
+            yield return new CompoundedTimelossComparisonGenerator(run);
             yield return new NoneComparisonGenerator(run);
         }
     }

--- a/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
@@ -51,6 +51,7 @@ namespace LiveSplit.Options.SettingsFactories
                     { WorstSegmentsComparisonGenerator.ComparisonName, false},
                     { PercentileComparisonGenerator.ComparisonName, false },
                     { LatestRunComparisonGenerator.ComparisonName, false },
+                    { CompoundedTimelossComparisonGenerator.ComparisonName, false },
                     { NoneComparisonGenerator.ComparisonName, false }
                 }
             };

--- a/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
@@ -23,6 +23,7 @@ namespace LiveSplit.View
                 WorstSegmentsComparisonGenerator.ComparisonName,
                 PercentileComparisonGenerator.ComparisonName,
                 LatestRunComparisonGenerator.ComparisonName,
+                CompoundedTimelossComparisonGenerator.ComparisonName,
                 NoneComparisonGenerator.ComparisonName
             });
         }


### PR DESCRIPTION
compounded timeloss adds all timeloss to the first split and compares against best segment for the remaining splits.